### PR TITLE
fix: allow 2 letter subreddits to be captured

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ const Settings = require("./Components/Settings");
 
 const componentTypesToCheck = ["u", "em", "strong"];
 
-const tagRegex = /(?<!\w)\/?[ur]\/[a-zA-Z_\-0-9]{3,21}/g;
+const tagRegex = /(?<!\w)\/?[ur]\/[a-zA-Z_\-0-9]{2,21}/g;
 
 module.exports = class RedditParser extends Plugin {
   async startPlugin() {


### PR DESCRIPTION
Currently 2 letter subreddits, like [r/de](https://www.reddit.com/r/de/) do not get picked up.
This issue might have slipped through the cracks because Reddit no longer allows the creation of 2 letter subreddits.
This PR fixes this by expanding the scope of the RegEx that's used to pick up subreddits in chat.